### PR TITLE
Rayon paralellism

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -339,6 +339,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "image",
+ "rayon",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -49,6 +60,43 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea54a38e4bce14ff6931c72e5b3c43da7051df056913d4e7e1fcdb1c03df69d"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "once_cell",
+ "strsim",
+ "termcolor",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42f169caba89a7d512b5418b09864543eeb4d497416c917d7137863bd2076ad"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d4198f73e42b4936b35b5bb248d81d2b595ecb170da0bac7655c54eedfa8da8"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "color_quant"
@@ -203,6 +251,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,6 +337,7 @@ dependencies = [
 name = "mandelbrot"
 version = "0.1.0"
 dependencies = [
+ "clap",
  "image",
 ]
 
@@ -369,6 +424,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e82dad04139b71a90c080c8463fe0dc7902db5192d939bd0950f074d014339e1"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff7415e9ae3fff1225851df9e0d9e4e5479f947619774677a63572e55e80eff"
+
+[[package]]
 name = "pin-project"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +459,30 @@ dependencies = [
  "crc32fast",
  "flate2",
  "miniz_oxide 0.5.4",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -470,6 +555,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -478,6 +569,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -505,6 +605,12 @@ name = "unicode-ident"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ceab39d59e4c9499d4e5a8ee0e2735b891bb7308ac83dfb4e80cad195c9f6f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "wasi"
@@ -571,3 +677,34 @@ name = "weezl"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9193164d4de03a926d909d3bc7c30543cecb35400c02114792c2cae20d5e2dbb"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+clap = { version = "4.0.14", features = ["derive"] }
 image = "0.24.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 clap = { version = "4.0.14", features = ["derive"] }
 image = "0.24.4"
+rayon = "1.5.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,23 +1,30 @@
 use std::fs;
 
 use clap::Parser;
-use image::{Rgb, RgbImage};
+use image::RgbImage;
 
-struct RGB {
+#[derive(Clone, Copy)]
+struct Rgb {
     red: u8,
     green: u8,
     blue: u8,
 }
 
+impl From<Rgb> for image::Rgb<u8> {
+    fn from(rgb: Rgb) -> Self {
+        image::Rgb([rgb.red, rgb.green, rgb.blue])
+    }
+}
+
 #[derive(Parser)]
 struct Args {
-    #[arg(long, short, default_value="5000")]
+    #[arg(long, short, default_value = "5000")]
     width: u32,
-    #[arg(long, short, default_value="5000")]
+    #[arg(long, short, default_value = "5000")]
     height: u32,
-    #[arg(long, short, default_value="1")]
+    #[arg(long, short, default_value = "1")]
     frames: usize,
-    #[arg(long, short, default_value="false")]
+    #[arg(long, short, default_value = "false")]
     colorful: bool,
 }
 
@@ -72,12 +79,17 @@ fn generate_zoom(
 
 ///Generates an image of the mandelbrot set
 fn generate_image(args: &Args, x_min: f64, x_max: f64, y_min: f64, y_max: f64, img_number: usize) {
-    let Args { width, height, colorful, .. } = *args;
+    let Args {
+        width,
+        height,
+        colorful,
+        ..
+    } = *args;
 
     fs::create_dir_all("./output/").expect("Creating output folder");
 
     let mut img = RgbImage::new(width, height);
-    let mut rgb: RGB = RGB {
+    let mut rgb: Rgb = Rgb {
         red: 0,
         green: 0,
         blue: 0,
@@ -92,8 +104,8 @@ fn generate_image(args: &Args, x_min: f64, x_max: f64, y_min: f64, y_max: f64, i
             let b_start = b;
             let c_abs = (a.powf(2.0) + b.powf(2.0)).sqrt();
 
-            if !((a + 1.0).powf(2.0) * b.powf(2.0) < 0.0625)
-                || !(c_abs.powf(2.0) * (8.0 * c_abs.powf(2.0) - 3.0) <= 0.09375 - a)
+            if (a + 1.0).powf(2.0) * b.powf(2.0) >= 0.0625
+                || c_abs.powf(2.0) * (8.0 * c_abs.powf(2.0) - 3.0) > 0.09375 - a
             {
                 while n < 255 {
                     let aa = a * a - b * b;
@@ -123,12 +135,10 @@ fn generate_image(args: &Args, x_min: f64, x_max: f64, y_min: f64, y_max: f64, i
                 rgb.blue = n;
             }
 
-
-            img.put_pixel(x, y, Rgb([rgb.red, rgb.green, rgb.blue]));
+            img.put_pixel(x, y, rgb.into());
         }
     }
-    let outputpath: String =
-        "./output/".to_string() + &img_number.to_string() + &".png".to_string();
+    let outputpath: String = format!("./output/{}.png", img_number);
     img.save(outputpath).expect("Writing image to png");
 }
 
@@ -137,8 +147,8 @@ fn map(x: f64, min: f64, max: f64, a: f64, b: f64) -> f64 {
     (x - min) / (max - min) * (b - a) + a
 }
 
-///Generates RGB values from HSL values
-fn hsl_to_rgb(hue: f32, saturation: f32, luminance: f32) -> RGB {
+///Generates Rgb values from HSL values
+fn hsl_to_rgb(hue: f32, saturation: f32, luminance: f32) -> Rgb {
     let c = (1.0 - (2.0 * luminance - 1.0).abs()) * saturation;
     let h = hue * 6.0;
     let x = c * (1.0 - (h % 2.0 - 1.0).abs());
@@ -155,7 +165,7 @@ fn hsl_to_rgb(hue: f32, saturation: f32, luminance: f32) -> RGB {
         rgb_table[(i / 2 + 2) % 3],
     );
 
-    RGB {
+    Rgb {
         red: ((r + m) * 255.0) as u8,
         green: ((g + m) * 255.0) as u8,
         blue: ((b + m) * 255.0) as u8,

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,9 @@
 use std::fs;
+use std::sync::Mutex;
 
 use clap::Parser;
 use image::RgbImage;
+use rayon::prelude::*;
 
 #[derive(Clone, Copy)]
 struct Rgb {
@@ -88,14 +90,9 @@ fn generate_image(args: &Args, x_min: f64, x_max: f64, y_min: f64, y_max: f64, i
 
     fs::create_dir_all("./output/").expect("Creating output folder");
 
-    let mut img = RgbImage::new(width, height);
-    let mut rgb: Rgb = Rgb {
-        red: 0,
-        green: 0,
-        blue: 0,
-    };
-    for x in 0..width {
-        for y in 0..height {
+    let img = Mutex::new(RgbImage::new(width, height));
+    (0..height).into_par_iter().for_each(|y| {
+        for x in 0..width {
             let mut a: f64 = map(x as f64, 0.0, width as f64, x_min, x_max);
             let mut b: f64 = map(y as f64, 0.0, height as f64, y_min, y_max);
             let mut n = 0;
@@ -123,22 +120,26 @@ fn generate_image(args: &Args, x_min: f64, x_max: f64, y_min: f64, y_max: f64, i
                 n = 255;
             }
 
-            if n == 255 {
-                rgb.red = 0;
-                rgb.green = 0;
-                rgb.blue = 0;
+            let rgb = if n == 255 {
+                Rgb {
+                    red: 0,
+                    green: 0,
+                    blue: 0,
+                }
             } else if colorful {
-                rgb = hsl_to_rgb(n as f32 / 255.0, 1.0, 0.5);
+                hsl_to_rgb(n as f32 / 255.0, 1.0, 0.5)
             } else {
-                rgb.red = n;
-                rgb.green = n;
-                rgb.blue = n;
-            }
-
-            img.put_pixel(x, y, rgb.into());
+                Rgb {
+                    red: n,
+                    green: n,
+                    blue: n,
+                }
+            };
+            img.lock().unwrap().put_pixel(x, y, rgb.into());
         }
-    }
+    });
     let outputpath: String = format!("./output/{}.png", img_number);
+    let img = img.into_inner().unwrap();
     img.save(outputpath).expect("Writing image to png");
 }
 


### PR DESCRIPTION
Added a bit of `rayon` to parallelize pixel generation. About a 4× speedup with the default options on my box. The first commit shows a slow way to do it, the second commit is faster.

Depends on PR #2, #3.